### PR TITLE
feature: dao communities announcements

### DIFF
--- a/announcements.go
+++ b/announcements.go
@@ -1,0 +1,315 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/vocdoni/vote-frame/farcasterapi/warpcast"
+	"github.com/vocdoni/vote-frame/mongo"
+	"go.vocdoni.io/dvote/httprouter"
+	"go.vocdoni.io/dvote/httprouter/apirest"
+	"go.vocdoni.io/dvote/log"
+	"go.vocdoni.io/dvote/util"
+)
+
+const (
+	DefaultAnnouncementTimeSpan = 24 * time.Hour
+)
+
+// communityUserProfiles returns a map of user fids and usernames of DAOs
+// communities, which census is based on NFTs or ERC20 tokens. The function
+// fetches the holders of the community census addresses using census3 and
+// then fetches the user profiles from the database based on the addresses
+// fetched.
+func (v *vocdoniHandler) communityUserProfiles(community *mongo.Community) (map[uint64]string, error) {
+	if community.Census.Type != mongo.TypeCommunityCensusNFT &&
+		community.Census.Type != mongo.TypeCommunityCensusERC20 {
+		return nil, fmt.Errorf("unsupported community census type: %s", community.Census.Type)
+	}
+	if len(community.Census.Addresses) == 0 {
+		return nil, fmt.Errorf("empty community census addresses")
+	}
+	chainIDs := map[string]uint64{}
+	for _, contract := range community.Census.Addresses {
+		switch contract.Blockchain {
+		case "ethereum":
+			chainIDs[contract.Blockchain] = 1
+		case "base":
+			chainIDs[contract.Blockchain] = 8453
+		case "zora":
+			chainIDs[contract.Blockchain] = 7777777
+		case "degen":
+			chainIDs[contract.Blockchain] = 666666666
+		default:
+			return nil, fmt.Errorf("unsupported blockchain: %s", contract.Blockchain)
+		}
+	}
+	// create two goroutines, one to fetch holders from census3 and another
+	// to fetch user profiles from the database based on the addresses fetched
+	// create a channel to communicate the fetched holders, a list to store the
+	// final results and a waitgroup to wait for the goroutines to finish
+	communityUsers := make(map[uint64]string)
+	holderAddrsCh := make(chan string)
+	waiter := sync.WaitGroup{}
+	// create a list to store the background errors and a mutex to protect it
+	var errsMtx sync.Mutex
+	var backgroundErrs []error
+
+	// fetch user profiles from the database based on the addresses fetched
+	waiter.Add(1)
+	go func() {
+		defer waiter.Done()
+		for addr := range holderAddrsCh {
+			user, err := v.db.UserByAddress(addr)
+			if err != nil {
+				errsMtx.Lock()
+				backgroundErrs = append(backgroundErrs, fmt.Errorf("failed to get user by address: %w", err))
+				errsMtx.Unlock()
+				continue
+			}
+			communityUsers[user.UserID] = user.Username
+		}
+	}()
+	// fetch holders from the community census addresses using census3
+	waiter.Add(1)
+	go func() {
+		defer waiter.Done()
+		// close the channel when the goroutine finishes to signal the other goroutine
+		// to finish
+		defer close(holderAddrsCh)
+		for _, contractAddr := range community.Census.Addresses {
+			chainID, ok := chainIDs[contractAddr.Blockchain]
+			if !ok {
+				errsMtx.Lock()
+				backgroundErrs = append(backgroundErrs, fmt.Errorf("missing chain id for blockchain: %s", contractAddr.Blockchain))
+				errsMtx.Unlock()
+				continue
+			}
+			tokenInfo, err := v.census3.Token(contractAddr.Address, chainID, "")
+			if err != nil {
+				errsMtx.Lock()
+				backgroundErrs = append(backgroundErrs, fmt.Errorf("failed to get token info: %w", err))
+				errsMtx.Unlock()
+				continue
+			}
+			holdersQueueID, err := v.census3.HoldersByStrategy(tokenInfo.DefaultStrategy)
+			if err != nil {
+				errsMtx.Lock()
+				backgroundErrs = append(backgroundErrs, fmt.Errorf("failed to get holders queue id: %w", err))
+				errsMtx.Unlock()
+				continue
+			}
+			for {
+				holders, finished, err := v.census3.HoldersByStrategyQueue(
+					tokenInfo.DefaultStrategy, holdersQueueID)
+				if err != nil {
+					errsMtx.Lock()
+					backgroundErrs = append(backgroundErrs, fmt.Errorf("failed to get holders by strategy queue: %w", err))
+					errsMtx.Unlock()
+					break
+				}
+				if finished {
+					for holderAddr := range holders {
+						holderAddrsCh <- holderAddr.String()
+					}
+					break
+				}
+			}
+		}
+	}()
+	// wait for the goroutines to finish
+	waiter.Wait()
+	// check if there were any background errors
+	if len(backgroundErrs) > 0 {
+		return nil, fmt.Errorf("failed to get user profiles: %v", backgroundErrs)
+	}
+	if len(communityUsers) == 0 {
+		return nil, fmt.Errorf("no users in the community")
+	}
+	return communityUsers, nil
+}
+
+// usersToAnnounceHandler returns a list of users to announce in a community.
+// The list will contain the user fids and usernames of the users in the
+// community.
+func (v *vocdoniHandler) usersToAnnounceHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
+	return ctx.Send([]byte("not implemented"), http.StatusNotImplemented)
+}
+
+// sendAnnouncementsHandler sends an announcement for the commununity requested
+// with the content and to the users specified in the request. The announcement
+// is sent via warpcast api, using the api key of the user that sends the
+// announcement. The user must be an admin of the community to send the
+// announcement. The users to send the announcement to must be part of the
+// community. The announcement is sent in background and the status of the task
+// can be checked with the queueID returned in the response.
+func (v *vocdoniHandler) sendAnnouncementsHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
+	// get community id from the URL
+	communityID, _, _, err := v.parseCommunityIDFromURL(ctx)
+	if err != nil {
+		return ctx.Send([]byte(err.Error()), http.StatusBadRequest)
+	}
+	// get the authenticated user from the token
+	token := msg.AuthToken
+	if token == "" {
+		return fmt.Errorf("missing auth token header")
+	}
+	auth, err := v.db.UpdateActivityAndGetData(token)
+	if err != nil {
+		return ctx.Send([]byte(err.Error()), apirest.HTTPstatusNotFound)
+	}
+	// get the announcement request from the body and validate it
+	req := AnnouncementRequest{}
+	if err := json.Unmarshal(msg.Data, &req); err != nil {
+		return ctx.Send([]byte("failed to unmarshal announcement request: "+err.Error()), http.StatusBadRequest)
+	}
+	if req.Content == "" {
+		return ctx.Send([]byte("missing content in announcement request"), http.StatusBadRequest)
+	}
+	if len(req.Users) == 0 {
+		return ctx.Send([]byte("missing users in announcement request"), http.StatusBadRequest)
+	}
+	// get access profile to use the warpcast api key of the current user
+	accessProfile, err := v.db.UserAccessProfile(auth.UserID)
+	if err != nil {
+		return ctx.Send([]byte(err.Error()), http.StatusInternalServerError)
+	}
+	// check if the user has a configured warpcast api key
+	if accessProfile == nil || accessProfile.WarpcastAPIKey == "" {
+		return ctx.Send([]byte("no warpcast api key configured"), http.StatusBadRequest)
+	}
+	// get the community from the database
+	dbCommunity, err := v.db.Community(communityID)
+	if err != nil {
+		return ctx.Send([]byte(err.Error()), http.StatusInternalServerError)
+	}
+	if dbCommunity == nil {
+		return ctx.Send([]byte("community not found"), http.StatusNotFound)
+	}
+	// check if the user is admin of the community
+	isAdmin := false
+	for _, admin := range dbCommunity.Admins {
+		if admin == auth.UserID {
+			isAdmin = true
+			break
+		}
+	}
+	if !isAdmin {
+		return ctx.Send([]byte("user is not an admin of the community"), http.StatusForbidden)
+	}
+	// check if the last community announcement is older than the default time span
+	if dbCommunity.LastAnnouncement.Add(DefaultAnnouncementTimeSpan).After(time.Now()) {
+		return ctx.Send([]byte("last announcement was less than 24 hours ago"), http.StatusBadRequest)
+	}
+	// init warpcast client to send the reminders with the user warpcast api key
+	warpcastClient := warpcast.NewWarpcastAPI()
+	if err := warpcastClient.SetFarcasterUser(auth.UserID, accessProfile.WarpcastAPIKey); err != nil {
+		return ctx.Send([]byte("failed to initialize warpcast client: "+err.Error()), http.StatusInternalServerError)
+	}
+	// init the background queue to store the status of the announcement task
+	taskID := util.RandomHex(16)
+	v.backgroundQueue.Store(taskID, AnnouncementStatus{
+		CommunityID: communityID,
+		Total:       len(req.Users),
+	})
+	// send the announcement to all the users of the community
+	go func() {
+		// get the status of the task from the background queue
+		s, _ := v.backgroundQueue.Load(taskID)
+		currentStatus := s.(AnnouncementStatus)
+		// create a context to cancel the task if needed
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		// get the list of users of the community
+		communityUsers, err := v.communityUserProfiles(dbCommunity)
+		if err != nil {
+			log.Warnw("failed to get community users", "error", err)
+			currentStatus.Error = err.Error()
+			v.backgroundQueue.Store(taskID, currentStatus)
+			return
+		}
+		// send the announcement to the users in the community
+		for fid, username := range req.Users {
+			// check if the user is in the community
+			if _, ok := communityUsers[fid]; !ok {
+				currentStatus.Fails[username] = "user not in community"
+				v.backgroundQueue.Store(taskID, currentStatus)
+				continue
+			}
+			// send the announcement to the user via warpcast api
+			if err := warpcastClient.DirectMessage(ctx, req.Content, fid); err != nil {
+				log.Warnw("failed to send direct notification",
+					"error", err,
+					"fid", fid,
+					"username", username)
+				currentStatus.Fails[username] = err.Error()
+				v.backgroundQueue.Store(taskID, currentStatus)
+				continue
+			}
+			currentStatus.AlreadySent++
+			v.backgroundQueue.Store(taskID, currentStatus)
+		}
+		currentStatus.Completed = true
+		v.backgroundQueue.Store(taskID, currentStatus)
+		// update the last announcement time of the community
+		if err := v.db.SetCommunityLastAnnouncement(communityID, time.Now()); err != nil {
+			log.Warnf("failed to update community last announcement: %v", err)
+		}
+	}()
+	res, err := json.Marshal(&AnnouncementResponse{QueuedID: taskID})
+	if err != nil {
+		return ctx.Send([]byte("failed to marshal announcement response: "+err.Error()), http.StatusInternalServerError)
+	}
+	return ctx.Send(res, http.StatusOK)
+}
+
+// announcementsQueueHandler returns the status of the announcement task with
+// the queueID specified in the URL. The status of the task contains the total
+// number of users to send the announcement to, the number of users already
+// sent the announcement, the list of users that failed to receive the
+// announcement and the error message if the task failed and a flag to indicate
+// if the task is completed (with success or failure).
+func (v *vocdoniHandler) announcementsQueueHandler(msg *apirest.APIdata, ctx *httprouter.HTTPContext) error {
+	// get the authenticated user from the token and check if the user is logged in
+	token := msg.AuthToken
+	if token == "" {
+		return fmt.Errorf("missing auth token header")
+	}
+	if _, err := v.db.UpdateActivityAndGetData(token); err != nil {
+		return ctx.Send([]byte(err.Error()), apirest.HTTPstatusNotFound)
+	}
+	// get community id from the URL
+	communityID, _, _, err := v.parseCommunityIDFromURL(ctx)
+	if err != nil {
+		return ctx.Send([]byte(err.Error()), http.StatusBadRequest)
+	}
+	// get the queue id from the url params
+	queueID := ctx.URLParam("queueID")
+	if queueID == "" {
+		return ctx.Send([]byte("missing queueID"), http.StatusBadRequest)
+	}
+	// get the status of the reminders task from the background queue
+	status, ok := v.backgroundQueue.Load(queueID)
+	if !ok {
+		return ctx.Send([]byte("task not found"), http.StatusNotFound)
+	}
+	currentStatus := status.(AnnouncementStatus)
+	// check if the community match the task
+	if currentStatus.CommunityID != communityID {
+		return ctx.Send([]byte("task does not match the community"), http.StatusBadRequest)
+	}
+	// check if the task is completed and remove it from the queue
+	if currentStatus.Completed {
+		v.backgroundQueue.Delete(queueID)
+	}
+	// encode the status of the task
+	res, err := json.Marshal(currentStatus)
+	if err != nil {
+		return fmt.Errorf("failed to marshal reminders response: %w", err)
+	}
+	return ctx.Send(res, http.StatusOK)
+}

--- a/communities.go
+++ b/communities.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/vocdoni/vote-frame/communityhub"
@@ -213,18 +214,19 @@ func (v *vocdoniHandler) listCommunitiesHandler(msg *apirest.APIdata, ctx *httpr
 		}
 		// add community to the list
 		communities.Communities = append(communities.Communities, &Community{
-			ID:              c.ID,
-			Name:            c.Name,
-			LogoURL:         c.ImageURL,
-			GroupChatURL:    c.GroupChatURL,
-			Admins:          admins,
-			Notifications:   c.Notifications,
-			CensusType:      c.Census.Type,
-			CensusAddresses: cAddresses,
-			CensusChannel:   cChannel,
-			UserRef:         userRef,
-			Channels:        c.Channels,
-			Disabled:        c.Disabled,
+			ID:                   c.ID,
+			Name:                 c.Name,
+			LogoURL:              c.ImageURL,
+			GroupChatURL:         c.GroupChatURL,
+			Admins:               admins,
+			Notifications:        c.Notifications,
+			CensusType:           c.Census.Type,
+			CensusAddresses:      cAddresses,
+			CensusChannel:        cChannel,
+			UserRef:              userRef,
+			Channels:             c.Channels,
+			Disabled:             c.Disabled,
+			CanSendAnnouncements: c.LastAnnouncement.Add(DefaultAnnouncementTimeSpan).Before(time.Now()),
 		})
 	}
 	res, err := json.Marshal(communities)
@@ -276,18 +278,19 @@ func (v *vocdoniHandler) communityHandler(msg *apirest.APIdata, ctx *httprouter.
 	}
 	// encode the community
 	res, err := json.Marshal(Community{
-		ID:              dbCommunity.ID,
-		Name:            dbCommunity.Name,
-		LogoURL:         dbCommunity.ImageURL,
-		GroupChatURL:    dbCommunity.GroupChatURL,
-		Admins:          admins,
-		Notifications:   dbCommunity.Notifications,
-		CensusType:      dbCommunity.Census.Type,
-		CensusAddresses: cAddresses,
-		CensusChannel:   cChannel,
-		UserRef:         userRef,
-		Channels:        dbCommunity.Channels,
-		Disabled:        dbCommunity.Disabled,
+		ID:                   dbCommunity.ID,
+		Name:                 dbCommunity.Name,
+		LogoURL:              dbCommunity.ImageURL,
+		GroupChatURL:         dbCommunity.GroupChatURL,
+		Admins:               admins,
+		Notifications:        dbCommunity.Notifications,
+		CensusType:           dbCommunity.Census.Type,
+		CensusAddresses:      cAddresses,
+		CensusChannel:        cChannel,
+		UserRef:              userRef,
+		Channels:             dbCommunity.Channels,
+		Disabled:             dbCommunity.Disabled,
+		CanSendAnnouncements: dbCommunity.LastAnnouncement.Add(DefaultAnnouncementTimeSpan).Before(time.Now()),
 	})
 	if err != nil {
 		return ctx.Send([]byte("error encoding community"), http.StatusInternalServerError)

--- a/handler.go
+++ b/handler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
+	c3cli "github.com/vocdoni/census3/apiclient"
 	"github.com/vocdoni/vote-frame/airstack"
 	"github.com/vocdoni/vote-frame/communityhub"
 	"github.com/vocdoni/vote-frame/farcasterapi"
@@ -43,6 +44,7 @@ type vocdoniHandler struct {
 	electionLRU   *lru.Cache[string, *api.Election]
 	fcapi         farcasterapi.API
 	airstack      *airstack.Airstack
+	census3       *c3cli.HTTPclient
 	comhub        *communityhub.CommunityHub
 	repUpdater    *reputation.Updater
 
@@ -61,6 +63,7 @@ func NewVocdoniHandler(
 	fcapi farcasterapi.API,
 	token *uuid.UUID,
 	airstack *airstack.Airstack,
+	census3 *c3cli.HTTPclient,
 	comhub *communityhub.CommunityHub,
 	repUpdater *reputation.Updater,
 	adminFID uint64,
@@ -100,6 +103,7 @@ func NewVocdoniHandler(
 		db:            db,
 		fcapi:         fcapi,
 		airstack:      airstack,
+		census3:       census3,
 		comhub:        comhub,
 		repUpdater:    repUpdater,
 		adminFID:      adminFID,

--- a/main.go
+++ b/main.go
@@ -360,7 +360,7 @@ func main() {
 	// Create the Vocdoni handler
 	apiTokenUUID := uuid.MustParse(apiToken)
 	handler, err := NewVocdoniHandler(apiEndpoint, vocdoniPrivKey, censusInfo,
-		webAppDir, db, mainCtx, neynarcli, &apiTokenUUID, as, comHub, repUpdater, adminFID)
+		webAppDir, db, mainCtx, neynarcli, &apiTokenUUID, as, census3Client, comHub, repUpdater, adminFID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -736,6 +736,18 @@ func main() {
 	}
 
 	if err := uAPI.Endpoint.RegisterMethod("/communities/{chainAlias}:{communityID}/delegations", http.MethodGet, "public", handler.communityDelegationsHandler); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := uAPI.Endpoint.RegisterMethod("/communities/{chainAlias}:{communityID}/announcements/users", http.MethodGet, "private", handler.usersToAnnounceHandler); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := uAPI.Endpoint.RegisterMethod("/communities/{chainAlias}:{communityID}/announcements", http.MethodPost, "private", handler.sendAnnouncementsHandler); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := uAPI.Endpoint.RegisterMethod("/communities/{chainAlias}:{communityID}/announcements/queue/{queueID}", http.MethodGet, "private", handler.announcementsQueueHandler); err != nil {
 		log.Fatal(err)
 	}
 

--- a/mongo/community.go
+++ b/mongo/community.go
@@ -327,3 +327,14 @@ func (ms *MongoStorage) SetCommunityNotifications(communityID string, enabled bo
 	_, err := ms.communities.UpdateOne(ctx, bson.M{"_id": communityID}, bson.M{"$set": bson.M{"notifications": enabled}})
 	return err
 }
+
+// SetCommunityLastAnnouncement sets the last announcement time of the community
+// with the given ID.
+func (ms *MongoStorage) SetCommunityLastAnnouncement(communityID string, t time.Time) error {
+	ms.keysLock.Lock()
+	defer ms.keysLock.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := ms.communities.UpdateOne(ctx, bson.M{"_id": communityID}, bson.M{"$set": bson.M{"lastAnnouncement": t}})
+	return err
+}

--- a/mongo/types.go
+++ b/mongo/types.go
@@ -275,17 +275,18 @@ type ReputationRanking struct {
 
 // Community represents a community entry.
 type Community struct {
-	ID            string          `json:"id" bson:"_id"`
-	Name          string          `json:"name" bson:"name"`
-	Channels      []string        `json:"channels" bson:"channels"`
-	Census        CommunityCensus `json:"census" bson:"census"`
-	ImageURL      string          `json:"imageURL" bson:"imageURL"`
-	GroupChatURL  string          `json:"groupChatURL" bson:"groupChatURL"`
-	Creator       uint64          `json:"creator" bson:"creator"`
-	Admins        []uint64        `json:"owners" bson:"owners"`
-	Notifications bool            `json:"notifications" bson:"notifications"`
-	Disabled      bool            `json:"disabled" bson:"disabled"`
-	Featured      bool            `json:"featured" bson:"featured"`
+	ID               string          `json:"id" bson:"_id"`
+	Name             string          `json:"name" bson:"name"`
+	Channels         []string        `json:"channels" bson:"channels"`
+	Census           CommunityCensus `json:"census" bson:"census"`
+	ImageURL         string          `json:"imageURL" bson:"imageURL"`
+	GroupChatURL     string          `json:"groupChatURL" bson:"groupChatURL"`
+	Creator          uint64          `json:"creator" bson:"creator"`
+	Admins           []uint64        `json:"owners" bson:"owners"`
+	Notifications    bool            `json:"notifications" bson:"notifications"`
+	Disabled         bool            `json:"disabled" bson:"disabled"`
+	Featured         bool            `json:"featured" bson:"featured"`
+	LastAnnouncement time.Time       `json:"lastAnnouncement" bson:"lastAnnouncement"`
 }
 
 const (

--- a/types.go
+++ b/types.go
@@ -134,18 +134,19 @@ type CensusAddress struct {
 // (FarcasterProfile), the census addresses (CensusAddress) and the channels
 // (Channel)
 type Community struct {
-	ID              string           `json:"id"`
-	Name            string           `json:"name"`
-	LogoURL         string           `json:"logoURL"`
-	GroupChatURL    string           `json:"groupChat"`
-	Admins          []*User          `json:"admins,omitempty"`
-	Notifications   bool             `json:"notifications"`
-	CensusType      string           `json:"censusType,omitempty"`
-	CensusAddresses []*CensusAddress `json:"censusAddresses,omitempty"`
-	CensusChannel   *Channel         `json:"censusChannel,omitempty"`
-	UserRef         *User            `json:"userRef,omitempty"`
-	Channels        []string         `json:"channels,omitempty"`
-	Disabled        bool             `json:"disabled"`
+	ID                   string           `json:"id"`
+	Name                 string           `json:"name"`
+	LogoURL              string           `json:"logoURL"`
+	GroupChatURL         string           `json:"groupChat"`
+	Admins               []*User          `json:"admins,omitempty"`
+	Notifications        bool             `json:"notifications"`
+	CensusType           string           `json:"censusType,omitempty"`
+	CensusAddresses      []*CensusAddress `json:"censusAddresses,omitempty"`
+	CensusChannel        *Channel         `json:"censusChannel,omitempty"`
+	UserRef              *User            `json:"userRef,omitempty"`
+	Channels             []string         `json:"channels,omitempty"`
+	Disabled             bool             `json:"disabled"`
+	CanSendAnnouncements bool             `json:"canSendAnnouncements"`
 }
 
 // CommunityList defines the list of communities
@@ -227,8 +228,7 @@ type RemindersStatus struct {
 // AnnouncementRequest defines the parameters to send an announcement, including
 // the content of the announcement and the users to send the announcement to.
 type AnnouncementRequest struct {
-	Content string            `json:"content"` // content of the reminder
-	Users   map[uint64]string `json:"users"`   // map of userFID to username
+	Content string `json:"content"` // content of the reminder
 }
 
 // AnnouncementResponse defines the response of an announcement request,

--- a/types.go
+++ b/types.go
@@ -224,6 +224,35 @@ type RemindersStatus struct {
 	Fails       map[string]string `json:"fails,omitempty"`
 }
 
+// AnnouncementRequest defines the parameters to send an announcement, including
+// the content of the announcement and the users to send the announcement to.
+type AnnouncementRequest struct {
+	Content string            `json:"content"` // content of the reminder
+	Users   map[uint64]string `json:"users"`   // map of userFID to username
+}
+
+// AnnouncementResponse defines the response of an announcement request,
+// including the queue ID of the background process that will send the
+// announcement. It allows to check the status of the process.
+type AnnouncementResponse struct {
+	QueuedID string `json:"queuedId"`
+}
+
+// AnnouncementStatus defines the status of an announcement process, including
+// the number of announcements that have been already sent, the total number of
+// announcements to send and the list of users that have failed to receive the
+// announcement (with the error message). It also includes the error message in
+// case of an global error and a flag to indicate if the process has been
+// completed.
+type AnnouncementStatus struct {
+	CommunityID string            `json:"communityId"`
+	Completed   bool              `json:"completed"`
+	AlreadySent int               `json:"alreadySent"`
+	Total       int               `json:"total"`
+	Fails       map[string]string `json:"fails,omitempty"`
+	Error       string            `json:"error,omitempty"`
+}
+
 // ComposerActionResponse is the response of the composer endpoint, which is a
 // redirection to the composer app to be used to create a new election from the
 // cast form in warpcast.

--- a/webapp/src/components/Communities/Notify.tsx
+++ b/webapp/src/components/Communities/Notify.tsx
@@ -1,0 +1,137 @@
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Button,
+  Checkbox,
+  FormControl,
+  FormErrorMessage,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Progress,
+  Textarea,
+  useDisclosure,
+  VStack,
+} from '@chakra-ui/react'
+import { useMutation } from '@tanstack/react-query'
+import { useForm } from 'react-hook-form'
+import { AiOutlineNotification } from 'react-icons/ai'
+import { useAuth } from '~components/Auth/useAuth'
+import { WarpcastApiKey } from '~components/WarpcastApiKey'
+import { appUrl, RoutePath } from '~constants'
+import { useWarpcastApiEnabled } from '~queries/profile'
+
+export const NotifyMembers = ({ community }: { community: Community }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { data: apiEnabled, isLoading } = useWarpcastApiEnabled()
+  return (
+    <>
+      <Button onClick={onOpen} leftIcon={<AiOutlineNotification />}>
+        Notify members
+      </Button>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Notify community members</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            {isLoading ? (
+              <Progress size='xs' isIndeterminate />
+            ) : apiEnabled ? (
+              <NotifyMembersForm community={community} onClose={onClose} />
+            ) : (
+              <WarpcastApiKey />
+            )}
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}
+
+type NotifyMembersFormValues = {
+  content: string
+  appendUrl: boolean
+}
+
+type NotifyMembersFormProps = {
+  community: Community
+  onClose: () => void
+}
+
+export const NotifyMembersForm = ({ community, onClose }: NotifyMembersFormProps) => {
+  const { bfetch } = useAuth()
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<NotifyMembersFormValues>({
+    defaultValues: {
+      content: '',
+      appendUrl: false,
+    },
+  })
+
+  const mutation = useMutation({
+    mutationFn: async (data: NotifyMembersFormValues) => {
+      const uri = appUrl + RoutePath.Community.replace(':chain/:id', community.id.replace(':', '/'))
+      const content = data.appendUrl ? `${data.content} - ${uri}` : data.content
+
+      console.log('content:', content, uri)
+
+      return await bfetch(`${appUrl}/communities/${community.id}/announcements`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ content }),
+      })
+    },
+    onSuccess: () => {
+      onClose()
+      reset()
+    },
+  })
+
+  return (
+    <form
+      onSubmit={handleSubmit(async (data: NotifyMembersFormValues) => {
+        console.log('data:', data)
+        return await mutation.mutate(data)
+      })}
+    >
+      <VStack spacing={4} alignItems='start'>
+        <FormControl isInvalid={!!errors.content}>
+          <Textarea
+            id='content'
+            placeholder='Enter your message here...'
+            {...register('content', { required: 'Content is required' })}
+          />
+          <FormErrorMessage>{errors.content?.message}</FormErrorMessage>
+        </FormControl>
+
+        <FormControl>
+          <Checkbox id='appendUrl' {...register('appendUrl')}>
+            Append my community URL to the message
+          </Checkbox>
+        </FormControl>
+        {mutation.error && (
+          <Alert status='error'>
+            <AlertIcon />
+            <AlertDescription>{mutation.error.toString()}</AlertDescription>
+          </Alert>
+        )}
+
+        <Button type='submit' alignSelf='end' colorScheme='purple' isLoading={mutation.status === 'pending'}>
+          Send Notification
+        </Button>
+      </VStack>
+    </form>
+  )
+}

--- a/webapp/src/components/Communities/View.tsx
+++ b/webapp/src/components/Communities/View.tsx
@@ -39,6 +39,7 @@ import { humanDate, participation } from '~util/strings'
 import { CensusTypeInfo } from './CensusTypeInfo'
 import { Delegates } from './Delegates'
 import { ManageCommunity } from './Manage'
+import { NotifyMembers } from './Notify'
 
 type CommunitiesViewProps = {
   community?: Community
@@ -119,6 +120,7 @@ export const CommunitiesView = ({ community, chain: chainAlias, refetch }: Commu
                     <Button leftIcon={<MdHowToVote />}>Create vote</Button>
                   </RouterLink>
                 )}
+                <NotifyMembers community={community} />
               </Flex>
             )}
           </Box>

--- a/webapp/src/components/WarpcastApiKey.tsx
+++ b/webapp/src/components/WarpcastApiKey.tsx
@@ -74,7 +74,13 @@ export const WarpcastApiKey: React.FC = (props: BoxProps) => {
                 <FormControl isInvalid={!!errors.apikey}>
                   <Input
                     placeholder='Paste here your API Key'
-                    {...register('apikey', { required: 'This field is required' })}
+                    {...register('apikey', {
+                      required: 'This field is required',
+                      minLength: {
+                        message: 'Too short, are you sure this is a valid API Key?',
+                        value: 64,
+                      },
+                    })}
                   />
                   <FormErrorMessage>{errors.apikey?.message?.toString()}</FormErrorMessage>
                 </FormControl>

--- a/webapp/src/components/WarpcastApiKey.tsx
+++ b/webapp/src/components/WarpcastApiKey.tsx
@@ -1,28 +1,12 @@
-import {
-  Box,
-  BoxProps,
-  Button,
-  FormControl,
-  FormErrorMessage,
-  Heading,
-  HStack,
-  Input,
-  Link,
-  Text,
-  VStack,
-} from '@chakra-ui/react'
-import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { Box, BoxProps, Button, FormControl, FormErrorMessage, HStack, Input, Link, Text } from '@chakra-ui/react'
+import { useMutation } from '@tanstack/react-query'
 import { useForm } from 'react-hook-form'
-
 import { appUrl } from '~constants'
-import { fetchWarpcastAPIEnabled } from '~queries/profile'
+import { useWarpcastApiEnabled } from '~queries/profile'
 import { useAuth } from './Auth/useAuth'
 import { Check } from './Check'
 
-type WarpcastApiKeyFormValues = {
-  apikey: string
-}
+type WarpcastApiKeyFormValues = { apikey: string }
 
 export const WarpcastApiKey: React.FC = (props: BoxProps) => {
   const {
@@ -32,106 +16,93 @@ export const WarpcastApiKey: React.FC = (props: BoxProps) => {
     setError,
     formState: { errors },
   } = useForm<WarpcastApiKeyFormValues>({
-    defaultValues: {
-      apikey: '',
-    },
+    defaultValues: { apikey: '' },
   })
   const { bfetch } = useAuth()
-  const [loading, setLoading] = useState<boolean>(false)
-  const {
-    data: isAlreadyEnabled,
-    error,
-    isLoading,
-    refetch,
-  } = useQuery<boolean, Error>({
-    queryKey: ['apiKeyEnabled'],
-    queryFn: fetchWarpcastAPIEnabled(bfetch),
-  })
+  const { data: isAlreadyEnabled, error, isLoading, refetch } = useWarpcastApiEnabled()
 
-  const onSubmit = async (data: WarpcastApiKeyFormValues) => {
-    setLoading(true)
-    try {
+  const { mutate: setApiKey, status: setApiKeyStatus } = useMutation({
+    mutationFn: async (apikey: string) => {
       await bfetch(`${appUrl}/profile/warpcast`, {
         method: 'POST',
-        body: JSON.stringify({ apikey: data.apikey }),
-      }).then(() => refetch())
-      reset({ apikey: '' }) // Reset the apikey field
-    } catch (e) {
-      if (e instanceof Error) {
-        setError('apikey', { message: e.message })
+        body: JSON.stringify({ apikey }),
+      })
+    },
+    onSuccess: () => {
+      reset({ apikey: '' })
+      refetch()
+    },
+    onError: (error: any) => {
+      if (error instanceof Error) {
+        setError('apikey', { message: error.message })
       }
-      console.error('could not set apikey', e)
-    } finally {
-      setLoading(false)
-    }
-  }
+      console.error('could not set apikey', error)
+    },
+  })
 
-  const revokeApiKey = async () => {
-    setLoading(true)
-    try {
+  const { mutate: revokeApiKey, status: revokeApiKeyStatus } = useMutation({
+    mutationFn: async () => {
       await bfetch(`${appUrl}/profile/warpcast`, {
         method: 'POST',
         body: JSON.stringify({ apikey: null }),
-      }).then(() => refetch())
-      reset({ apikey: '' }) // Reset the apikey field
-    } catch (e) {
-      if (e instanceof Error) {
-        setError('apikey', { message: e.message })
+      })
+    },
+    onSuccess: () => {
+      reset({ apikey: '' })
+      refetch()
+    },
+    onError: (error: any) => {
+      if (error instanceof Error) {
+        setError('apikey', { message: error.message })
       }
-      console.error('could not set apikey', e)
-    } finally {
-      setLoading(false)
-    }
+      console.error('could not set apikey', error)
+    },
+  })
+
+  const onSubmit = (data: WarpcastApiKeyFormValues) => {
+    setApiKey(data.apikey)
   }
 
   return (
-    <Box borderRadius='md' p={4} bg='purple.100' {...props}>
-      <Heading fontSize='xl' mb={4} fontWeight='600' color='purple.800' pos='relative'>
-        Warpcast Api Key
-      </Heading>
-      <VStack spacing={4} align='stretch'>
-        <Text>Set your Warpcast API Key here to unlock awesome features like poll reminders.</Text>
-        {(isLoading || error) && <Check isLoading={isLoading} error={error} />}
-
-        {!isAlreadyEnabled && (
-          <>
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <Box borderRadius='md' p={4} bg='purple.50'>
-                <HStack spacing={4}>
-                  <FormControl isInvalid={!!errors.apikey}>
-                    <Input
-                      placeholder='Paste here your API Key'
-                      {...register('apikey', { required: 'This field is required' })}
-                    />
-                    <FormErrorMessage>{errors.apikey?.message?.toString()}</FormErrorMessage>
-                  </FormControl>
-                  <Button type='submit' colorScheme='purple' flexGrow={1} isLoading={loading}>
-                    Save
-                  </Button>
-                </HStack>
-                <Text fontSize={'sm'} mt={2}>
-                  Get your Warpcast API Key from the{' '}
-                  <Link textDecoration='underline' href='https://warpcast.com/~/developers/api-keys' isExternal>
-                    official developer portal
-                  </Link>
-                  .
-                </Text>
-              </Box>
-            </form>
-          </>
-        )}
-
-        {isAlreadyEnabled && (
-          <>
-            <HStack spacing={4} p={4} bg='purple.50' borderRadius='md'>
-              <Text>You already registered a valid API Key.</Text>
-              <Button colorScheme='red' isLoading={loading} onClick={revokeApiKey}>
-                Revoke
-              </Button>
-            </HStack>
-          </>
-        )}
-      </VStack>
+    <Box borderRadius='md' {...props}>
+      {(isLoading || error) && <Check isLoading={isLoading} error={error} />}
+      {!isLoading && !isAlreadyEnabled && (
+        <>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Box borderRadius='md' p={4} bg='purple.50'>
+              <HStack spacing={4}>
+                <FormControl isInvalid={!!errors.apikey}>
+                  <Input
+                    placeholder='Paste here your API Key'
+                    {...register('apikey', { required: 'This field is required' })}
+                  />
+                  <FormErrorMessage>{errors.apikey?.message?.toString()}</FormErrorMessage>
+                </FormControl>
+                <Button type='submit' colorScheme='purple' flexGrow={1} isLoading={setApiKeyStatus === 'pending'}>
+                  Save
+                </Button>
+              </HStack>
+              <Text fontSize={'sm'} mt={2}>
+                Get your Warpcast API Key from the{' '}
+                <Link textDecoration='underline' href='https://warpcast.com/~/developers/api-keys' isExternal>
+                  official developer portal
+                </Link>
+                .
+              </Text>
+            </Box>
+          </form>
+        </>
+      )}
+      {!isLoading && isAlreadyEnabled && (
+        <>
+          <HStack spacing={4} p={4} bg='purple.50' borderRadius='md'>
+            <Text>You already registered a valid API Key.</Text>
+            <Button colorScheme='red' isLoading={revokeApiKeyStatus === 'pending'} onClick={() => revokeApiKey()}>
+              Revoke
+            </Button>
+          </HStack>
+        </>
+      )}
     </Box>
   )
 }

--- a/webapp/src/pages/Profile.tsx
+++ b/webapp/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, GridItem, Link, Text, VStack } from '@chakra-ui/react'
+import { Box, Grid, GridItem, Heading, Link, Text, VStack } from '@chakra-ui/react'
 import { useParams } from 'react-router-dom'
 import { useAuth } from '~components/Auth/useAuth'
 import { Check } from '~components/Check'
@@ -64,7 +64,7 @@ const Profile = () => {
       </GridItem>
       <GridItem gridArea='muted'>{isOwnProfile && <MutedUsersList list={user?.mutedUsers} />}</GridItem>
       <GridItem gridArea='delegations'>{isOwnProfile && <Delegations delegations={user?.delegations} />}</GridItem>
-      <GridItem gridArea='warpcastapikey'>{isOwnProfile && <WarpcastApiKey />}</GridItem>
+      <GridItem gridArea='warpcastapikey'>{isOwnProfile && <ProfileWarpcastApiKey />}</GridItem>
       <GridItem gridArea='polls'>
         <UserPolls
           polls={user?.polls || []}
@@ -75,5 +75,16 @@ const Profile = () => {
     </Grid>
   )
 }
+
+const ProfileWarpcastApiKey = () => (
+  <PurpleBox>
+    <Heading fontSize='xl' fontWeight='600' color='purple.800' pos='relative'>
+      Warpcast Api Key
+    </Heading>
+    <Text>Set your Warpcast API Key here to unlock awesome features like poll reminders.</Text>
+
+    <WarpcastApiKey />
+  </PurpleBox>
+)
 
 export default Profile

--- a/webapp/src/queries/profile.ts
+++ b/webapp/src/queries/profile.ts
@@ -44,6 +44,15 @@ export const fetchWarpcastAPIEnabled = (bfetch: FetchFunction) => async (): Prom
   return data.warpcastApiEnabled
 }
 
+export const useWarpcastApiEnabled = () => {
+  const { bfetch } = useAuth()
+
+  return useQuery<boolean, Error>({
+    queryKey: ['apiKeyEnabled'],
+    queryFn: fetchWarpcastAPIEnabled(bfetch),
+  })
+}
+
 export const useFirstDegenOrEnsName = (addresses: string[] = []) => {
   const { degen: connected } = useHealthcheck()
   const { getContract } = useBlockchain(degen)

--- a/webapp/types.d.ts
+++ b/webapp/types.d.ts
@@ -214,6 +214,7 @@ declare global {
     user: User
     reputation?: Reputation
     delegations?: Delegation[]
+    warpcastApiEnabled: boolean
   }
 
   type Channel = {


### PR DESCRIPTION
Allow to admins of DAO communities (token based census communities) to send announcements about the community to its members (token holders).

Three problems to solve:
 - [x] Send announcements in background serving the status of the process, to allow to the UI to show that information to the admins.