### PR TITLE
Feature: census3 token-based censuses

### DIFF
--- a/communities.go
+++ b/communities.go
@@ -65,7 +65,7 @@ func (v *vocdoniHandler) CommunityStatus(community *mongo.Community) (bool, int,
 	nTokens := len(community.Census.Addresses)
 	// iterate over the addresses of the community getting status of token in census3
 	for _, contract := range community.Census.Addresses {
-		chainID, ok := communityhub.ChainIDByShortName[contract.Blockchain]
+		chainID, ok := v.comhub.Census3ChainID(contract.Blockchain)
 		if !ok {
 			return false, 0, fmt.Errorf("invalid blockchain alias")
 		}

--- a/communities.go
+++ b/communities.go
@@ -17,13 +17,6 @@ import (
 	"go.vocdoni.io/dvote/log"
 )
 
-var chainIDByShortName = map[string]uint64{
-	"ethereum": 1,
-	"base":     8453,
-	"zora":     7777777,
-	"degen":    666666666,
-}
-
 func (v *vocdoniHandler) parseCommunityIDFromURL(ctx *httprouter.HTTPContext) (string, string, uint64, error) {
 	// get community id from the URL
 	strID := ctx.URLParam("communityID")
@@ -72,7 +65,7 @@ func (v *vocdoniHandler) CommunityStatus(community *mongo.Community) (bool, int,
 	nTokens := len(community.Census.Addresses)
 	// iterate over the addresses of the community getting status of token in census3
 	for _, contract := range community.Census.Addresses {
-		chainID, ok := chainIDByShortName[contract.Blockchain]
+		chainID, ok := communityhub.ChainIDByShortName[contract.Blockchain]
 		if !ok {
 			return false, 0, fmt.Errorf("invalid blockchain alias")
 		}

--- a/communityhub/errors.go
+++ b/communityhub/errors.go
@@ -6,6 +6,9 @@ var (
 	// ErrMissingDB is returned when no database is provided during CommunituHub
 	// initialization
 	ErrMissingDB = fmt.Errorf("missing db")
+	// ErrMissingCensus3 is returned when no census3 client is provided during
+	// CommunityHub initialization
+	ErrMissingCensus3 = fmt.Errorf("missing db")
 	// ErrMissingContracts is returned when no contracts addresses and chain ids
 	// are provided during CommunityHub initialization
 	ErrMissingContracts = fmt.Errorf("missing contracts addresses and chain id")

--- a/communityhub/hub.go
+++ b/communityhub/hub.go
@@ -645,7 +645,7 @@ func (ch *CommunityHub) registerTokenAddresses(hcommunity *HubCommunity) error {
 			ID:      cAddress.Address.Hex(),
 			Type:    tokenType,
 			ChainID: chainID,
-		}); err != nil {
+		}); err != nil && !errors.Is(err, c3cli.ErrAlreadyExists) {
 			return err
 		}
 		// set the flag to know if there are new tokens to create their strategy
@@ -690,7 +690,7 @@ func (ch *CommunityHub) registerTokenAddresses(hcommunity *HubCommunity) error {
 			Predicate: strings.Join(tokenAliases, fmt.Sprintf(" %s ", strategyoperators.ORSUMTag)),
 			Tokens:    predicateTokens,
 		})
-		if err != nil {
+		if err != nil && !errors.Is(err, c3cli.ErrAlreadyExists) {
 			return err
 		}
 	}

--- a/communityhub/types.go
+++ b/communityhub/types.go
@@ -25,6 +25,13 @@ const (
 	CensusTypeFollowers CensusType = "followers"
 )
 
+var ChainIDByShortName = map[string]uint64{
+	"ethereum": 1,
+	"base":     8453,
+	"zora":     7777777,
+	"degen":    666666666,
+}
+
 const (
 	// CONTRACT_CENSUS_TYPE_FC represents the census type for all farcaster
 	// users in the CommunityHub contract

--- a/communityhub/types.go
+++ b/communityhub/types.go
@@ -25,13 +25,6 @@ const (
 	CensusTypeFollowers CensusType = "followers"
 )
 
-var ChainIDByShortName = map[string]uint64{
-	"ethereum": 1,
-	"base":     8453,
-	"zora":     7777777,
-	"degen":    666666666,
-}
-
 const (
 	// CONTRACT_CENSUS_TYPE_FC represents the census type for all farcaster
 	// users in the CommunityHub contract

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/vocdoni/census3 v0.1.4-0.20240821110304-47cab1ebc275
+	github.com/vocdoni/census3 v0.1.4-0.20240821113728-3e2e7c59d5ef
 	github.com/xakep666/mongo-migrate v0.3.2
 	github.com/zeebo/blake3 v0.2.3
 	go.mongodb.org/mongo-driver v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/vocdoni/census3 v0.1.4-0.20240821072831-6d791e7f6899
+	github.com/vocdoni/census3 v0.1.4-0.20240821110304-47cab1ebc275
 	github.com/xakep666/mongo-migrate v0.3.2
 	github.com/zeebo/blake3 v0.2.3
 	go.mongodb.org/mongo-driver v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/vocdoni/census3 v0.1.4-0.20240717111508-91f43dd8bde5
+	github.com/vocdoni/census3 v0.1.4-0.20240821072831-6d791e7f6899
 	github.com/xakep666/mongo-migrate v0.3.2
 	github.com/zeebo/blake3 v0.2.3
 	go.mongodb.org/mongo-driver v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -1486,8 +1486,8 @@ github.com/vektah/gqlparser/v2 v2.5.1 h1:ZGu+bquAY23jsxDRcYpWjttRZrUz07LbiY77gUO
 github.com/vektah/gqlparser/v2 v2.5.1/go.mod h1:mPgqFBu/woKTVYWyNk8cO3kh4S/f4aRFZrvOnp3hmCs=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/vocdoni/census3 v0.1.4-0.20240821110304-47cab1ebc275 h1:14BK2pjnsq6U0jTKZImN9HxKoNX3iZeo8ovHlNn6YHc=
-github.com/vocdoni/census3 v0.1.4-0.20240821110304-47cab1ebc275/go.mod h1:7KLBLNKtZk2O0nWaM64vfeF6eNhvxyXOPudxpgdWH+4=
+github.com/vocdoni/census3 v0.1.4-0.20240821113728-3e2e7c59d5ef h1:MdJKw0hWSzNS+UPQmZ0WYBtL5WvxD91bwhpUWFF1TC8=
+github.com/vocdoni/census3 v0.1.4-0.20240821113728-3e2e7c59d5ef/go.mod h1:7KLBLNKtZk2O0nWaM64vfeF6eNhvxyXOPudxpgdWH+4=
 github.com/vocdoni/storage-proofs-eth-go v0.1.6 h1:mF6VNGudgCjjgjxs5Z2GGMM2tS79+xFBWcr7BnPuhAY=
 github.com/vocdoni/storage-proofs-eth-go v0.1.6/go.mod h1:aoD9pKg8kDFQ5I6b3obGPTwjC+DsaW2h4wt2UQEjQrg=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=

--- a/go.sum
+++ b/go.sum
@@ -1486,8 +1486,8 @@ github.com/vektah/gqlparser/v2 v2.5.1 h1:ZGu+bquAY23jsxDRcYpWjttRZrUz07LbiY77gUO
 github.com/vektah/gqlparser/v2 v2.5.1/go.mod h1:mPgqFBu/woKTVYWyNk8cO3kh4S/f4aRFZrvOnp3hmCs=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/vocdoni/census3 v0.1.4-0.20240717111508-91f43dd8bde5 h1:7JhSV33TWBevfRbGpGLKe72kilesUee9XjH/48jcs1A=
-github.com/vocdoni/census3 v0.1.4-0.20240717111508-91f43dd8bde5/go.mod h1:7KLBLNKtZk2O0nWaM64vfeF6eNhvxyXOPudxpgdWH+4=
+github.com/vocdoni/census3 v0.1.4-0.20240821072831-6d791e7f6899 h1:RVxSaSrep7cEtFfMCmJ1Xc3m8ETxlW2+EQMiH9b9uRo=
+github.com/vocdoni/census3 v0.1.4-0.20240821072831-6d791e7f6899/go.mod h1:7KLBLNKtZk2O0nWaM64vfeF6eNhvxyXOPudxpgdWH+4=
 github.com/vocdoni/storage-proofs-eth-go v0.1.6 h1:mF6VNGudgCjjgjxs5Z2GGMM2tS79+xFBWcr7BnPuhAY=
 github.com/vocdoni/storage-proofs-eth-go v0.1.6/go.mod h1:aoD9pKg8kDFQ5I6b3obGPTwjC+DsaW2h4wt2UQEjQrg=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=

--- a/go.sum
+++ b/go.sum
@@ -1486,8 +1486,8 @@ github.com/vektah/gqlparser/v2 v2.5.1 h1:ZGu+bquAY23jsxDRcYpWjttRZrUz07LbiY77gUO
 github.com/vektah/gqlparser/v2 v2.5.1/go.mod h1:mPgqFBu/woKTVYWyNk8cO3kh4S/f4aRFZrvOnp3hmCs=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
-github.com/vocdoni/census3 v0.1.4-0.20240821072831-6d791e7f6899 h1:RVxSaSrep7cEtFfMCmJ1Xc3m8ETxlW2+EQMiH9b9uRo=
-github.com/vocdoni/census3 v0.1.4-0.20240821072831-6d791e7f6899/go.mod h1:7KLBLNKtZk2O0nWaM64vfeF6eNhvxyXOPudxpgdWH+4=
+github.com/vocdoni/census3 v0.1.4-0.20240821110304-47cab1ebc275 h1:14BK2pjnsq6U0jTKZImN9HxKoNX3iZeo8ovHlNn6YHc=
+github.com/vocdoni/census3 v0.1.4-0.20240821110304-47cab1ebc275/go.mod h1:7KLBLNKtZk2O0nWaM64vfeF6eNhvxyXOPudxpgdWH+4=
 github.com/vocdoni/storage-proofs-eth-go v0.1.6 h1:mF6VNGudgCjjgjxs5Z2GGMM2tS79+xFBWcr7BnPuhAY=
 github.com/vocdoni/storage-proofs-eth-go v0.1.6/go.mod h1:aoD9pKg8kDFQ5I6b3obGPTwjC+DsaW2h4wt2UQEjQrg=
 github.com/wangjia184/sortedset v0.0.0-20160527075905-f5d03557ba30/go.mod h1:YkocrP2K2tcw938x9gCOmT5G5eCD6jsTz0SZuyAqwIE=

--- a/handler.go
+++ b/handler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/uuid"
 	lru "github.com/hashicorp/golang-lru/v2"
+	c3cli "github.com/vocdoni/census3/apiclient"
 	"github.com/vocdoni/vote-frame/airstack"
 	"github.com/vocdoni/vote-frame/communityhub"
 	"github.com/vocdoni/vote-frame/farcasterapi"
@@ -43,6 +44,7 @@ type vocdoniHandler struct {
 	electionLRU   *lru.Cache[string, *api.Election]
 	fcapi         farcasterapi.API
 	airstack      *airstack.Airstack
+	census3       *c3cli.HTTPclient
 	comhub        *communityhub.CommunityHub
 	repUpdater    *reputation.Updater
 
@@ -61,6 +63,7 @@ func NewVocdoniHandler(
 	fcapi farcasterapi.API,
 	token *uuid.UUID,
 	airstack *airstack.Airstack,
+	census3 *c3cli.HTTPclient,
 	comhub *communityhub.CommunityHub,
 	repUpdater *reputation.Updater,
 	adminFID uint64,
@@ -100,6 +103,7 @@ func NewVocdoniHandler(
 		db:            db,
 		fcapi:         fcapi,
 		airstack:      airstack,
+		census3:       census3,
 		comhub:        comhub,
 		repUpdater:    repUpdater,
 		adminFID:      adminFID,

--- a/main.go
+++ b/main.go
@@ -318,13 +318,14 @@ func main() {
 	// Create the community hub service
 	var comHub *communityhub.CommunityHub
 	if communityHubChainsConfigPath != "" && chainsConfs != nil {
-		comHub, err = communityhub.NewCommunityHub(mainCtx, web3pool, &communityhub.CommunityHubConfig{
-			ChainAliases:      chainsConfs.ChainChainIDByAlias(),
-			ContractAddresses: chainsConfs.ContractsAddressesByChainAlias(),
-			DB:                db,
-			PrivKey:           communityHubAdminPrivKey,
-		})
-		if err != nil {
+		if comHub, err = communityhub.NewCommunityHub(mainCtx, web3pool,
+			census3Client, &communityhub.CommunityHubConfig{
+				ChainAliases:      chainsConfs.ChainChainIDByAlias(),
+				ContractAddresses: chainsConfs.ContractsAddressesByChainAlias(),
+				DB:                db,
+				PrivKey:           communityHubAdminPrivKey,
+			},
+		); err != nil {
 			log.Warnw("failed to create community hub", "error", err)
 		}
 		comHub.ScanNewCommunities()

--- a/main.go
+++ b/main.go
@@ -351,7 +351,7 @@ func main() {
 	}
 
 	// start reputation updater
-	repUpdater, err := reputation.NewUpdater(mainCtx, db, neynarcli, as, census3Client, concurrentReputationUpdates)
+	repUpdater, err := reputation.NewUpdater(mainCtx, db, neynarcli, census3Client, concurrentReputationUpdates)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -616,6 +616,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if err := uAPI.Endpoint.RegisterMethod("/census/community/blockchains", http.MethodGet, "public", handler.tokenBasedCensusBlockchains); err != nil {
+		log.Fatal(err)
+	}
+
 	if err := uAPI.Endpoint.RegisterMethod("/census/check/{censusID}", http.MethodGet, "private", handler.censusQueueInfo); err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -628,19 +628,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if as != nil { // if airstack activated
-		if err := uAPI.Endpoint.RegisterMethod("/census/airstack/nft", http.MethodPost, "private", handler.censusTokenNFTAirstack); err != nil {
-			log.Fatal(err)
-		}
-
-		if err := uAPI.Endpoint.RegisterMethod("/census/airstack/erc20", http.MethodPost, "private", handler.censusTokenERC20Airstack); err != nil {
-			log.Fatal(err)
-		}
-		if err := uAPI.Endpoint.RegisterMethod("/census/airstack/blockchains", http.MethodGet, "public", handler.censusBlockchainsAirstack); err != nil {
-			log.Fatal(err)
-		}
-	}
-
 	if err := uAPI.Endpoint.RegisterMethod("/create/check/{electionID}", http.MethodGet, "public", handler.checkElection); err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -360,7 +360,8 @@ func main() {
 	// Create the Vocdoni handler
 	apiTokenUUID := uuid.MustParse(apiToken)
 	handler, err := NewVocdoniHandler(apiEndpoint, vocdoniPrivKey, censusInfo,
-		webAppDir, db, mainCtx, neynarcli, &apiTokenUUID, as, comHub, repUpdater, adminFID)
+		webAppDir, db, mainCtx, neynarcli, &apiTokenUUID, as, census3Client,
+		comHub, repUpdater, adminFID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -728,6 +729,10 @@ func main() {
 	}
 
 	if err := uAPI.Endpoint.RegisterMethod("/communities/{chainAlias}:{communityID}", http.MethodGet, "public", handler.communityHandler); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := uAPI.Endpoint.RegisterMethod("/communities/{chainAlias}:{communityID}/status", http.MethodGet, "public", handler.communityStatusHandler); err != nil {
 		log.Fatal(err)
 	}
 

--- a/mongo/types.go
+++ b/mongo/types.go
@@ -377,7 +377,6 @@ func dynamicUpdateDocument(item interface{}, alwaysUpdateTags []string) (bson.M,
 			update[tag] = field.Interface()
 		}
 	}
-
 	return bson.M{"$set": update}, nil
 }
 

--- a/mongo/types.go
+++ b/mongo/types.go
@@ -310,6 +310,7 @@ type CommunityCensus struct {
 	Type      string                     `json:"type" bson:"type"`
 	Addresses []CommunityCensusAddresses `json:"addresses" bson:"addresses"`
 	Channel   string                     `json:"channel" bson:"channel"`
+	Strategy  uint64                     `json:"strategy" bson:"strategy"`
 }
 
 // CommunityCensusAddresses represents the addresses of a contract to be used to

--- a/reputation/updater.go
+++ b/reputation/updater.go
@@ -888,31 +888,9 @@ func (u *Updater) userBoosters(user *dbmongo.User) *Boosters {
 // It returns the token holders as a map of addresses and balances. It returns an
 // error if the token holders data cannot be fetched.
 func (u *Updater) tokenHolders(address common.Address, chainID uint64) (map[common.Address]*big.Int, error) {
-	tokenHolders := make(map[common.Address]*big.Int)
 	tokenInfo, err := u.census3.Token(address.Hex(), chainID, "")
 	if err != nil {
 		return nil, fmt.Errorf("error getting token info: %w", err)
-	} else {
-		holdersQueueID, err := u.census3.HoldersByStrategy(tokenInfo.DefaultStrategy)
-		if err != nil {
-			return nil, fmt.Errorf("error getting KIWI holders queue ID: %w", err)
-		} else {
-			for {
-				holders, finished, err := u.census3.HoldersByStrategyQueue(
-					tokenInfo.DefaultStrategy, holdersQueueID)
-				if err != nil {
-					return nil, fmt.Errorf("error getting token holders from the queue: %w", err)
-				}
-				if finished {
-					for holder, balance := range holders {
-						if balance.Cmp(big.NewInt(0)) > 0 {
-							tokenHolders[holder] = balance
-						}
-					}
-					break
-				}
-			}
-		}
 	}
-	return tokenHolders, nil
+	return u.census3.AllHoldersByStrategy(tokenInfo.DefaultStrategy)
 }

--- a/scripts/census3_boosters/boosters.json
+++ b/scripts/census3_boosters/boosters.json
@@ -1,0 +1,16 @@
+{
+    "boosters_tokens": [
+        { "ID": "0x225D58E18218E8d87f365301aB6eEe4CbfAF820b", "chainID": 8453, "type": "erc721" },
+        { "ID": "0x32B6BB4d1f7298d4a80c2Ece237e4474C0880B69", "chainID": 8453, "type": "erc721" },
+        { "ID": "0x66747bdC903d17C586fA09eE5D6b54CC85bBEA45", "chainID": 10, "type": "erc721" },
+        { "ID": "0x980Fbdd1cF05080781Dca0AEf7026B0406743389", "chainID": 8453, "type": "erc721" },
+        { "ID": "0x85E7DF5708902bE39891d59aBEf8E21EDE91E8BF", "chainID": 8453, "type": "erc721" },
+        { "ID": "0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed", "chainID": 8453, "type": "erc20" },
+        { "ID": "0x432073397Aead241cf2411e21D8fA949183E7151", "chainID": 8453, "type": "erc721" },
+        { "ID": "0xA051A2Cb19C00eCDffaE94D0Ff98c17758041D16", "chainID": 666666666, "type": "erc20" },
+        { "ID": "0x7888b1f446c912ddec9bf582629e9ae8845fd8c6", "chainID": 8453, "type": "erc721" },
+        { "ID": "0x4087fb91A1fBdef05761C02714335D232a2Bf3a1", "chainID": 666666666, "type": "erc721" },
+        { "ID": "0xe03ef4b9db1a47464de84fb476f9baf493b3e886", "chainID": 7777777, "type": "erc721" },
+        { "ID": "0x235CAD50d8a510Bc9081279996f01877827142D8", "chainID": 8453, "type": "erc721" }
+    ]
+}

--- a/scripts/census3_boosters/create_tokens.sh
+++ b/scripts/census3_boosters/create_tokens.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Check if jq is installed
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is not installed. Please install jq to proceed."
+    exit 1
+fi
+
+# Check if the input file is provided as an argument
+if [ -z "$1" ]; then
+    echo "Error: No JSON file path provided."
+    echo "Usage: $0 /path/to/input.json"
+    exit 1
+fi
+
+# Input JSON file path
+INPUT_FILE="$1"
+
+# Check if the file exists
+if [ ! -f "$INPUT_FILE" ]; then
+    echo "Error: File '$INPUT_FILE' not found."
+    exit 1
+fi
+
+# Extract boosters_tokens array length
+LENGTH=$(jq '.boosters_tokens | length' $INPUT_FILE)
+
+# Loop through each item in the boosters_tokens list
+for ((i = 0; i < $LENGTH; i++)); do
+    # Extract each item as a JSON string
+    ITEM=$(jq -c ".boosters_tokens[$i]" $INPUT_FILE)
+
+    # Send POST request using wget
+    wget --quiet \
+        --method POST \
+        --header 'Accept: */*' \
+        --header 'Content-Type: application/json' \
+        --body-data "$ITEM" \
+        --output-document \
+        - https://census3-votecaster.vocdoni.net/api/tokens
+done

--- a/types.go
+++ b/types.go
@@ -146,6 +146,14 @@ type Community struct {
 	UserRef         *User            `json:"userRef,omitempty"`
 	Channels        []string         `json:"channels,omitempty"`
 	Disabled        bool             `json:"disabled"`
+	Ready           bool             `json:"ready"`
+}
+
+// CommunityStatus defines the status of a community, including if it is ready
+// to be used and the progress of the community setup
+type CommunityStatus struct {
+	Ready    bool `json:"ready"`
+	Progress int  `json:"progress"`
 }
 
 // CommunityList defines the list of communities

--- a/types.go
+++ b/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/vocdoni/vote-frame/mongo"
+	"github.com/vocdoni/vote-frame/reputation"
 )
 
 const (
@@ -11,6 +12,16 @@ const (
 	minPaginatedItems   = int64(1)
 	maxPaginatedItems   = int64(100)
 )
+
+// VotecasterProfile is the profile of a votecaster user.
+type VotecasterProfile struct {
+	User               *mongo.User             `json:"user"`
+	Polls              []mongo.ElectionRanking `json:"polls"`
+	MutedUsers         []*mongo.User           `json:"mutedUsers"`
+	Delegations        []mongo.Delegation      `json:"delegations"`
+	Reputation         reputation.Reputation  `json:"reputation"`
+	WarpcastAPIEnabled bool                    `json:"warpcastApiEnabled"`
+}
 
 // FarcasterProfile is the profile of a farcaster user.
 type FarcasterProfile struct {

--- a/users.go
+++ b/users.go
@@ -63,13 +63,11 @@ func (v *vocdoniHandler) profileHandler(msg *apirest.APIdata, ctx *httprouter.HT
 	} else {
 		profile.Reputation = *reputation.ReputationToAPIResponse(rep)
 	}
-	log.Info(profile)
 	// Marshal the response
 	data, err := json.Marshal(profile)
 	if err != nil {
 		return fmt.Errorf("could not marshal response: %v", err)
 	}
-	log.Info(string(data))
 	return ctx.Send(data, apirest.HTTPstatusOK)
 }
 

--- a/webapp/src/components/CensusTypeSelector.tsx
+++ b/webapp/src/components/CensusTypeSelector.tsx
@@ -29,7 +29,7 @@ import { useEffect, useState } from 'react'
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
 import { BiTrash } from 'react-icons/bi'
 import { MdArrowDropDown } from 'react-icons/md'
-import { fetchAirstackBlockchains } from '~queries/census'
+import { fetchTokenBasedBlockchains } from '~queries/census'
 import { fetchCommunitiesByAdmin } from '~queries/communities'
 import { ucfirst } from '~util/strings'
 import { useAuth } from './Auth/useAuth'
@@ -78,8 +78,7 @@ const CensusTypeSelector = ({
   })
   const { data: blockchains, isLoading: bloading } = useQuery({
     queryKey: ['blockchains'],
-    queryFn: fetchAirstackBlockchains(bfetch),
-    enabled: import.meta.env.airstackEnabled,
+    queryFn: fetchTokenBasedBlockchains(bfetch),
   })
   const {
     data: communities,
@@ -132,8 +131,8 @@ const CensusTypeSelector = ({
     { value: 'channel', label: '⛩ Farcaster channel gated' },
     { value: 'followers', label: '❤️ My Farcaster followers and me' },
     { value: 'custom', label: '🦄 Token based via CSV', visible: !!complete && !composer },
-    { value: 'nft', label: '🎨 NFT based via airstack', isDisabled: !import.meta.env.airstackEnabled },
-    { value: 'erc20', label: '💰 ERC20 based via airstack', isDisabled: !import.meta.env.airstackEnabled },
+    { value: 'nft', label: '🎨 NFT based via Census3' },
+    { value: 'erc20', label: '💰 ERC20 based via Census3' },
   ].filter((o) => o.visible !== false)
 
   return (
@@ -157,7 +156,7 @@ const CensusTypeSelector = ({
           <RadioGroup onChange={(val: CensusType) => setValue('censusType', val)} value={censusType} id='census-type'>
             <Stack direction='column' flexWrap='wrap'>
               {options.map((option, index) => (
-                <Radio key={index} value={option.value} isDisabled={option.isDisabled || isDisabled}>
+                <Radio key={index} value={option.value} isDisabled={isDisabled}>
                   {option.label}
                 </Radio>
               ))}
@@ -200,7 +199,7 @@ const CensusTypeSelector = ({
             <Flex>
               <Select
                 {...register(`addresses.${index}.blockchain`, { required })}
-                defaultValue='ethereum'
+                defaultValue='eth'
                 w='auto'
                 icon={bloading ? <Spinner /> : <MdArrowDropDown />}
               >

--- a/webapp/src/queries/census.ts
+++ b/webapp/src/queries/census.ts
@@ -1,7 +1,7 @@
 import { appUrl } from '~constants'
 
-export const fetchAirstackBlockchains = (bfetch: FetchFunction) => async () => {
-  const response = await bfetch(`${appUrl}/census/airstack/blockchains`)
+export const fetchTokenBasedBlockchains = (bfetch: FetchFunction) => async () => {
+  const response = await bfetch(`${appUrl}/census/community/blockchains`)
   const { blockchains } = (await response.json()) as { blockchains: string[] }
   return blockchains.sort()
 }


### PR DESCRIPTION
Replaces the use of Airstack to create token-based censuses with Census3.

Main changes:
* Now when the CommunityHub creates or updates a community from the blockchain, also tries to create the tokens of the community census in Census3 (it they are not already created) and stores the strategy ID in the database associated to the community.
* Now the list of communities and the community info endpoints includes a new flag `ready` that its true when the census tokens are synced in Census3.
* A new endpoint was created to check the status of the community census sync process in census3: `GET /communities/{communityID}/status`. Response:
  ```json
  {
    "ready": false,
    "progress": 78
  }
  ```
* Airstack census related endpoints was removed.